### PR TITLE
Replace old Kicad domain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NorBotKiCadFootprints.pretty
-Our custom PCB footprints for KiCad (www.kicad-pcb.org)
+Our custom PCB footprints for KiCad (www.kicad.org)
 
 ## How to add to KiCad ##
 


### PR DESCRIPTION
The old kicad domain was sold out from under the project.  More info: https://forum.kicad.info/t/warning-avoid-all-links-to-kicad-pcb-org-use-kicad-org/31521
I also recommend updating the description to also point to the new domain.